### PR TITLE
산 즐겨찾기, 난이도별 산 기능 구현

### DIFF
--- a/lib/provider/mountain_provider.dart
+++ b/lib/provider/mountain_provider.dart
@@ -1,6 +1,7 @@
 // providers/mountain_provider.dart
 import 'package:flutter/material.dart';
 import 'package:sancheck/service/mountain_service.dart';
+import 'package:sancheck/globals.dart'; // 전역 변수가 있는 파일 import
 
 class MountainProvider extends ChangeNotifier {
   final MountainService _mountainService = MountainService();
@@ -10,6 +11,14 @@ class MountainProvider extends ChangeNotifier {
 
   List<dynamic>? get mountain => _mountain;
   String? get searchText => _searchText;
+
+  // favMountains의 getter
+  List<dynamic>? get providerFavMountains => favMountains;
+
+  // favMountains 업데이트 시 상태 변화 알림
+  void updateFavMountain() {
+    notifyListeners(); // 상태 변화 알림
+  }
 
   // 산 검색 메서드
   Future<void> searchMountain(String queryText) async {

--- a/lib/screen/home.dart
+++ b/lib/screen/home.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:sancheck/globals.dart';
+import 'package:sancheck/service/mountain_service.dart';
 import '../provider/mountain_provider.dart';
 import 'gpx_navigation.dart'; // GpxNavigation 클래스를 포함한 파일을 import
 import 'home_mt_detail.dart'; // Import the detail page
@@ -158,7 +159,7 @@ class _HomeState extends State<Home> {
 
 class ExpandableButtonList extends StatefulWidget {
   final String title;
-  final List<dynamic> items;
+  final List<dynamic> items; //산 목록이 들어있는 배열
   final Color buttonColor;
   final String? iconUrl;
   final bool isNavigable;
@@ -180,37 +181,39 @@ class ExpandableButtonList extends StatefulWidget {
 }
 
 class _ExpandableButtonListState extends State<ExpandableButtonList> {
+  final MountainService _mountainService = MountainService();
   bool _isExpanded = false;
-  Set<String> favoriteItems = {};
-  List<dynamic> commonItems = [];
+  // List<dynamic> commonItems = [];
 
 
-  void searchCommonItems(){
-    // 겹치는 mount_idx를 가진 객체를 찾는 코드
-    commonItems = favMountains!.where((favItem) {
-      return widget.items.any((item) => item['mount_idx'] == favItem['mount_idx']);
-    }).toList();
-  }
+  // void searchCommonItems(){
+  //   // 관심있는 산에 들어있는지 확인 후 반환
+  //   commonItems = favMountains!.where((favItem) {
+  //     return widget.items.any((item) => item['mount_idx'] == favItem['mount_idx']);
+  //   }).toList();
+  // }
 
 
   @override
   void initState() {
-    // TODO: implement initState
     super.initState();
-
   }
 
   @override
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.of(context).size.width;
+    final mountainProvider = Provider.of<MountainProvider>(context); // Provider 접근
 
     return Padding(
       padding: EdgeInsets.all(screenWidth * 0.04),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // 누르면 isExpanded 토글 됨
-          _buildStyledButton(widget.title, iconUrl: widget.iconUrl, onPressed: () {
+          // isExpanded 토글 시키는 버튼
+          _buildStyledButton(
+              widget.title, 
+              iconUrl: widget.iconUrl, 
+              onPressed: () {
             setState(() {
               _isExpanded = !_isExpanded;
             });
@@ -221,31 +224,67 @@ class _ExpandableButtonListState extends State<ExpandableButtonList> {
             duration: Duration(milliseconds: 300),
             height: _isExpanded ? 200 : 0,
 
-            // 상위 위젯에서 items 가져와서 ListView로 빌드
+            // 상위 위젯에서 items 수 만큼 ListView 자식으로 빌드
             child: ListView.builder(
               itemCount: widget.items.length,
               itemBuilder: (context, index) {
+
+                var item = widget.items[index];
+                int? mountIdx;
+                // item이 Map일 경우 (mount_idx를 포함할 경우)
+                if (item is Map<String, dynamic> && item.containsKey('mount_idx')) {
+                   mountIdx = item['mount_idx'];
+                }
+
+                bool containedFavMt = mountIdx != null && favMountains!.any((favMt) => favMt['mount_idx'] == mountIdx);
+
+                Map<String, dynamic>? selectMt = mountIdx != null
+                    ? allMountains!.firstWhere(
+                      (element) => element['mount_idx'] == mountIdx,
+                  orElse: () => null,
+                )
+                    : null;
+
+                Future<void> addFavMountain(int mountIdx, String userId)async {
+                  await _mountainService.addFavMountain(mountIdx, userId);
+                }
+
+                Future<void> removeFavMountain(int mountIdx, String userId)async {
+                  await _mountainService.removeFavMountain(mountIdx, userId);
+                }
+
                 return Padding(
                   padding: EdgeInsets.symmetric(vertical: screenWidth * 0.01),
                   child: _buildStyledButton(
-                    widget.items[index],
+                    // 산 이름 or 난이도
+                    selectMt != null ? selectMt['mount_name'] : item,
 
-                    // 버튼 클릭 시 해당 페이지로 이동
+                    // 아이템 클릭 시 콜백(산 이름 가지고 detail 페이지로 이동 or 난이도 페이지로 이동)
                     onPressed: () {
                       if (widget.isNavigable && widget.navigateToPage != null) {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) =>
-                                widget.navigateToPage!(widget.items[index]),
-                          ),
-                        );
+                        if(selectMt != null){
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) =>
+                                  widget.navigateToPage!(selectMt['mount_name']),
+                            ),
+                          );
+                        }else{
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) =>
+                                  widget.navigateToPage!(item),
+                            ),
+                          );
+                        }
                       }
                     },
 
                     // 별 표시 여부
                     // showStarIcon이 true && 클릭한 아이템이 관심있는 산 목록에 있을 경우 : 채워진 별
-                    trailingIcon: widget.showStarIcon && commonItems.isNotEmpty
+                    trailingIcon: widget.showStarIcon && containedFavMt
                         ? Icons.star
                     // 반대일 경우 : 비워진 별
                         : widget.showStarIcon
@@ -254,14 +293,21 @@ class _ExpandableButtonListState extends State<ExpandableButtonList> {
                         : null, // 별 아이콘 표시 여부 조건 추가
                     
                     // 별 클릭 콜백
-                    onTrailingIconPressed: () {
-                      setState(() {
-                        if (favoriteItems.contains(widget.items[index])) {
-                          favoriteItems.remove(widget.items[index]);
+                    onTrailingIconPressed: () async{
+                        if (containedFavMt) {
+                          setState(() {
+                            favMountains!.removeWhere((item) => item['mount_idx'] == mountIdx);
+                          });
+                          await removeFavMountain(mountIdx!, userModel!.userId);
+
                         } else {
-                          favoriteItems.add(widget.items[index]);
+                          setState(() {
+                            favMountains!.add({'mount_idx': mountIdx, 'user_id': userModel!.userId});
+                          });
+                          await addFavMountain(mountIdx!, userModel!.userId);
+
                         }
-                      });
+
                     },
                   ),
                 );

--- a/lib/screen/home.dart
+++ b/lib/screen/home.dart
@@ -122,7 +122,7 @@ class _HomeState extends State<Home> {
                 SizedBox(height: screenHeight * 0.005),
                 ExpandableButtonList(
                   title: "난이도별 코스",
-                  items: ["쉬움", "보통", "어려움"],
+                  items: ["중간", "중간", "중간"],
                   buttonColor: Colors.orange,
                   iconUrl: 'https://img.icons8.com/color/96/sparkling.png',
                   isNavigable: true,

--- a/lib/screen/home_mt_detail.dart
+++ b/lib/screen/home_mt_detail.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:sancheck/globals.dart';
+import 'package:sancheck/provider/mountain_provider.dart';
 import 'package:sancheck/screen/login_success.dart';
 import 'package:sancheck/service/auth_service.dart';
 import 'package:sancheck/service/mountain_service.dart';
@@ -24,6 +26,7 @@ class _HomeMtDetailState extends State<HomeMtDetail> {
   Map<String, dynamic>? _mountain;
   int? _mountIdx;
   bool _containsMountIdx=false;
+
 
   // 데이터를 초기화하는 메서드
   Future<void> _initializeData() async{
@@ -106,6 +109,7 @@ class _HomeMtDetailState extends State<HomeMtDetail> {
 
   @override
   Widget build(BuildContext context) {
+    final mountainProvider = Provider.of<MountainProvider>(context); // Provider 접근
 
     final screenWidth = MediaQuery
         .of(context)
@@ -162,12 +166,14 @@ class _HomeMtDetailState extends State<HomeMtDetail> {
                       favMountains!.removeWhere((item) => item['mount_idx'] == _mountIdx);
                     });
                     await _removeFavMountain(_mountIdx!, userModel!.userId);
+                    mountainProvider.updateFavMountain();
 
                   } else { // favMt에 추가
                     setState(() {
                       favMountains!.add({'mount_idx': _mountIdx, 'user_id': userModel!.userId});
                     });
                     await _addFavMountain(_mountIdx!, userModel!.userId);
+                    mountainProvider.updateFavMountain();
                   }
                   // _containsMountIdx를 상태에 맞게 업데이트
                   setState(() {
@@ -313,7 +319,7 @@ class _HomeMtDetailState extends State<HomeMtDetail> {
                 padding: EdgeInsets.only(left: 10),
                 child: ElevatedButton(
                   // 길찾기 버튼 클릭 콜백
-                  onPressed:  () async{
+                  onPressed:  () {
                     selectedMountain = allMountains!.firstWhere(
                           (element) => element['mount_name'] == widget.mountainName,
                       orElse: () => null, // 조건에 맞는 값이 없을 경우 null 반환

--- a/lib/screen/home_mt_detail.dart
+++ b/lib/screen/home_mt_detail.dart
@@ -28,32 +28,9 @@ class _HomeMtDetailState extends State<HomeMtDetail> {
   bool _containsMountIdx=false;
 
 
-  // 데이터를 초기화하는 메서드
-  Future<void> _initializeData() async{
-    // mount_name을 통해 해당 맵을 가져옴
-    _mountain = allMountains?.firstWhere(
-          (mountain) => mountain['mount_name'] == widget.mountainName,
-      orElse: () => null, // 조건에 맞는 항목이 없을 경우 null 반환
-    );
-
-    // mount_idx를 가져옴
-    _mountIdx = _mountain != null ? _mountain!['mount_idx'] as int? : null;
-
-    // 추가적인 초기화 작업이 필요하다면 여기서 수행
-    print('Selected Mountain: $_mountain');
-    print('Mount Index: $_mountIdx');
-
-    // _mountIdx가 리스트에 있는지 확인
-    setState(() {
-      _containsMountIdx = favMountains!.any((item) => item['mount_idx'] == _mountIdx);
-      _isLoading = false;
-    });
-  }
-
-
   Future<void> _selectTrail() async {
     try {
-      List<dynamic> trails = await _trailService.selectTrail(widget.mountainName);
+      List<dynamic> trails = await _trailService.selectTrailByMountName(widget.mountainName);
       if(trails.isEmpty){
         return;
       } else {
@@ -98,6 +75,28 @@ class _HomeMtDetailState extends State<HomeMtDetail> {
     }
   }
 
+  // 데이터를 초기화하는 메서드
+  Future<void> _initializeData() async{
+    // mount_name을 통해 해당 맵을 가져옴
+    _mountain = allMountains?.firstWhere(
+          (mountain) => mountain['mount_name'] == widget.mountainName,
+      orElse: () => null, // 조건에 맞는 항목이 없을 경우 null 반환
+    );
+
+    // mount_idx를 가져옴
+    _mountIdx = _mountain != null ? _mountain!['mount_idx'] as int? : null;
+
+    // 추가적인 초기화 작업이 필요하다면 여기서 수행
+    print('Selected Mountain: $_mountain');
+    print('Mount Index: $_mountIdx');
+
+    // _mountIdx가 리스트에 있는지 확인
+    setState(() {
+      _containsMountIdx = favMountains!.any((item) => item['mount_idx'] == _mountIdx);
+      _isLoading = false;
+    });
+  }
+
 
   @override
   void initState() {
@@ -116,7 +115,7 @@ class _HomeMtDetailState extends State<HomeMtDetail> {
         .size
         .width;
 
-    if(_isLoading)
+    if(_isLoading) {
       return Scaffold(
         appBar: AppBar(
           title: Text('${widget.mountainName} 코스 리스트'),
@@ -132,6 +131,7 @@ class _HomeMtDetailState extends State<HomeMtDetail> {
         ),
         body: Center(child: CircularProgressIndicator()),
       );
+    }
 
 
     return Scaffold(

--- a/lib/screen/weather.dart
+++ b/lib/screen/weather.dart
@@ -92,15 +92,19 @@ class _WeatherModalState extends State<WeatherModal> {
 
   @override
   Widget build(BuildContext context) {
+  // 현재 날짜 및 시간 가져오기 (UTC 기준)
+    DateTime now = DateTime.now().toUtc();
 
-    // 현재 날짜 및 시간 가져오기
-    DateTime now = DateTime.now();
+    // UTC 기준으로 9시간을 더해 한국 시간으로 변환
+    DateTime kstNow = now.add(Duration(hours: 9));
 
     // 분을 00으로 고정한 새로운 DateTime 객체 생성
-    DateTime modifiedNow = DateTime(now.year, now.month, now.day, now.hour, 0);
+    DateTime modifiedNow = DateTime(kstNow.year, kstNow.month, kstNow.day, kstNow.hour, 0);
 
     // 날짜 및 시간 포맷 설정 (예: '2024/09/03 14:00')
     String formattedDate = DateFormat('yyyy/MM/dd HH:mm').format(modifiedNow);
+
+    print(formattedDate); // 올바른 한국 시간대 출력
 
     // 로딩 상태일 때 로딩 인디케이터 표시
 
@@ -193,7 +197,7 @@ class _WeatherModalState extends State<WeatherModal> {
                 formattedDate,
                 style: TextStyle(
                   color: Color(0xFF1E1E1E),
-                  fontSize: 8,
+                  fontSize: 14,
                 ),
               ),
             if (!_isLoading)

--- a/lib/service/api_service.dart
+++ b/lib/service/api_service.dart
@@ -16,7 +16,7 @@ class ApiService {
 
       print('Request URL: ${res.realUri}');
       print('Status Code: ${res.statusCode}');
-      print('Response Data: ${res.data}');
+      // print('Response Data: ${res.data}');
 
       // 요청 결과를 반환
       return {
@@ -43,7 +43,7 @@ class ApiService {
 
       print('Request URL: ${res.realUri}');
       print('Status Code: ${res.statusCode}');
-      print('Response Data: ${res.data}');
+      // print('Response Data: ${res.data}');
 
       bool isSuccessed = res.data['success'];
       var jsonData = res.data['data'];

--- a/lib/service/trail_service.dart
+++ b/lib/service/trail_service.dart
@@ -4,11 +4,33 @@ class TrailService{
   final Dio dio = Dio();
 
   // 등산로 가져오기
-  Future<List<dynamic>> selectTrail(String mountName) async {
+  Future<List<dynamic>> selectTrailByMountName(String mountName) async {
     try {
-      String url = "http://192.168.219.200:8000/trail/selectTrail";
+      String url = "http://192.168.219.200:8000/trail/selectTrailByMountName";
       Response res = await dio.get(url, queryParameters: {
         'mountName': mountName,
+      });
+
+      print('Request URL: ${res.realUri}');
+      print('Status Code: ${res.statusCode}');
+      //print('Response Data: ${res.data}');
+
+      if (res.data['success']) {
+        return res.data['trails']; // 성공 시 데이터 리스트 반환
+      } else {
+        throw Exception('검색 실패');
+      }
+    } catch (e) {
+      print('Error occurred: $e');
+      throw Exception('서버 요청 실패');
+    }
+  }
+
+  Future<List<dynamic>> selectTrailByTrailLevel(String trailLevel) async{
+    try {
+      String url = "http://192.168.219.200:8000/trail/selectTrailByTrailLevel";
+      Response res = await dio.get(url, queryParameters: {
+        'trailLevel': trailLevel,
       });
 
       print('Request URL: ${res.realUri}');


### PR DESCRIPTION
1. 산 즐겨찾기에서 '관심있는 산의 리스트뷰'가 열려있을 때 '인기있는 산의 별표'를 누를 시 
실시간으로 '관심있는 산의 리스트뷰' 변화 구현은 포기.

2. 난이도별 산에서 '중간'난이도의 산 등산로만 지도에 그릴 수 있고 또한 쉬움,보통,어려움으로 라벨링 분류가 되어있지 않아서
중간 난이도로만 테스트 함.
-> 나중에 db라벨링 끝나면 home페이지의 items : ['중간','중간','중간'] 부분을 items:['쉬움','보통','어려움'] 으로 바꾸면 됨